### PR TITLE
WDP210301-17

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -68,7 +68,7 @@ class NewFurniture extends React.Component {
           </div>
           <div className='row'>
             {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
-              <div key={item.id} className='col-3'>
+              <div key={item.id} className='col-6 col-md-4 col-lg-3'>
                 <ProductBox {...item} />
               </div>
             ))}

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -33,10 +33,12 @@
 
     .menu {
       text-align: center;
+
       ul {
         margin: 0;
         padding: 0;
         list-style: none;
+
         li {
           display: inline-block;
           margin: 0 0.5rem;
@@ -97,6 +99,21 @@
             }
           }
         }
+      }
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .root .panelBar .menu {
+    text-align: left;
+    padding-left: $base-padding / 4;
+
+    ul li {
+      margin: 0 0.1rem;
+
+      a {
+        font-size: 12px;
       }
     }
   }


### PR DESCRIPTION
> Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
> Ten task dotyczy sekcji "New furniture". 
> Klient chciałby na tabletach mieć po 2-3 elementy w rzędzie, a na mobilkach 1-2 w rzędzie. Klient podał orientacyjne liczby elementów, bo trzeba będzie samodzielnie zdecydować co wygląda ok. Robimy tylko trzy warianty: desktop, tablet i mobile.
> Docelowo na tabletach i mobilkach ma być tylko jeden rząd, a pozostałe dostępne za pomocą klikania w kropki paginacji (prawy górny róg tego komponentu), ale na to będzie osobne zadanie, na razie może się wyświetlać zawsze 8 produktów per strona.

Dodane RWD dla kafelków oraz dla przycisków menu w tym komponencie.