### PR TITLE
WDP210301-62 bug in Compare 

### DIFF
--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -18,7 +18,6 @@ const ProductBox = ({
   promo,
   stars,
   image,
-  number,
   favorite,
   toggleFavorite,
   id,
@@ -72,20 +71,14 @@ const ProductBox = ({
         <div className={styles.outlines}>
           <Button
             variant='outline'
-            className={
-              (number === 0 || number === 2 ? styles.favorite : '') +
-              (favorite ? styles.favorite : '')
-            }
+            className={favorite ? styles.favorite : ''}
             onClick={faveHandler}
           >
             <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
           </Button>
           <Button
             variant='outline'
-            className={
-              (number === 1 || number === 2 ? styles.compare : '') +
-              (compare ? styles.compare : '')
-            }
+            className={compare ? styles.compare : ''}
             onClick={comparisonHandler}
           >
             <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
@@ -118,7 +111,6 @@ ProductBox.propTypes = {
   toggleFavorite: PropTypes.func,
   favorite: PropTypes.bool,
   id: PropTypes.string,
-  number: PropTypes.number,
   comparisonHandler: PropTypes.func,
   compareItems: PropTypes.func,
   compare: PropTypes.bool,

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -117,14 +117,11 @@ class NewFurniture extends React.Component {
           <div
             className={'row' + (isFading ? ' ' + styles.fadeout : ' ' + styles.fadein)}
           >
-            {categoryProducts
-              .slice(activePage * itemsPerPage, (activePage + 1) * itemsPerPage)
-              .map((item, i) => (
-                <div key={item.id} className='col-6 col-md-4 col-lg-3'>
-                  <ProductBox image={image} {...item} number={i} product={item} />
-                </div>
-              ))
-            }
+            {categoryProducts.slice(activePage * 8, (activePage + 1) * 8).map(item => (
+              <div key={item.id} className='col-6 col-md-4 col-lg-3'>
+                <ProductBox {...item} />
+              </div>
+            ))}
           </div>
         </div>
       </Swipeable>

--- a/src/components/features/StickyBar/StickyBar.module.scss
+++ b/src/components/features/StickyBar/StickyBar.module.scss
@@ -5,6 +5,7 @@
   position: -webkit-sticky;
   position: sticky;
   bottom: 0;
+  z-index: 1;
 
   .stickyWrapper {
     position: relative;


### PR DESCRIPTION
Po zmianie stany przycisków odpowiadają danym pobieranym ze stanu produktów. Początkowo nic nie jest dodane do porównywarki. Porównywarka jest zawsze powyżej innych elementów strony za wyjątkiem Chat Boota.